### PR TITLE
Aplicar valores às variáveis fora do arquivo de script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,52 @@ Scripts e bibliotecas para a linguagem Shell para uso com a API da Nvoip.
 Este script irá disparar um SMS quando for acionado.
 Como usar: 
 
-1. Altere as variáveis $token_auth, $celular e $msg conforme a documentação da API da Nvoip.
+1. Aplique valores às variáveis de ambiente (opcional):
 
-2. Execute o script com o comando: sh send_sms_nvoip.sh
+```bash
+$ export NVOIP_TOKEN_AUTH=token
+$ export NVOIP_CELULAR=numero-do-celular
+$ export NVOIP_MSG=mensagem
+```
 
-5. Aguarde uns instantes que você irá receber o SMS.
+2. Execute o script com o comando:
+
+``` bash
+$ sh send_sms_nvoip.sh
+```
+ou, (caso não tenha seguido o passo 1):
+
+```bash
+$ NVOIP_TOKEN_AUTH=token NVOIP_CELULAR=numero-do-celular NVOIP_MSG=mensagem sh send_sms_nvoip.sh
+```
+
+3. Aguarde uns instantes que você irá receber o SMS.
 
 ### Disparo de Torpedo de Voz Shell Script - send_torpedovoz_nvoip.sh
 Este script irá disparar uma ligação de voz lendo o problema ocasionado através de TTS.
 
 Como usar: 
 
-1. Altere as variáveis $token_auth, $caller, $called e $audio conforme a documentação da API da Nvoip.
+1. Aplique valores às variáveis de ambiente (opcional):
 
-2. Execute o script com o comando: sh send_torpedovoz_nvoip.sh
+```bash
+$ export NVOIP_TOKEN_AUTH=token
+$ export NVOIP_CALLER=numero
+$ export NVOIP_CALLED=numero
+$ export NVOIP_AUDIO=caminho-arquivo-de-audio
+```
+
+2. Execute o script com o comando:
+
+```bash
+$ sh send_torpedovoz_nvoip.sh
+```
+
+ou, (caso não tenha seguido o passo 1):
+
+```bash
+$ NVOIP_TOKEN_AUTH=token NVOIP_CALLER=numero NVOIP_CALLED=numero NVOIP_AUDIO=caminho-arquivo-de-audio sh send_torpedovoz_nvoip.sh
+```
 
 3. Aguarde alguns segundos que você irá receber a ligação.
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,25 @@ Shell language scripts and libraries for use with the Nvoip API.
 This script will trigger an SMS when it fires.
 How to use it:
 
-1. Change the $token_auth, $mobile, and $msg variables according to Nvoip API documentation.
+1. Apply values to environment variables (optional):
 
-2. Run the script with the command: sh send_sms_nvoip.sh
+```bash
+$ export NVOIP_TOKEN_AUTH=token
+$ export NVOIP_CELULAR=number
+$ export NVOIP_MSG=message
+```
+
+2. Run the script with the command:
+
+```bash
+$ sh send_sms_nvoip.sh
+```
+
+or, (if you do not follow the step 1):
+
+```bash
+$ NVOIP_TOKEN_AUTH=token NVOIP_CELULAR=number NVOIP_MSG=message sh send_sms_nvoip.sh
+```
 
 3. Wait a moment you will receive the SMS.
 
@@ -83,8 +99,25 @@ How to use it:
 This script will trigger a voice call reading the problem caused through TTS.
 How to use it:
 
-1. Change the $token_auth, $caller, $called and $audio variables according to the Nvoip API documentation.
+1. Apply values to environment variables (optional):
 
-2. Run the script with the command: sh send_torpedovoz_nvoip.sh
+```bash
+$ export NVOIP_TOKEN_AUTH=token
+$ export NVOIP_CALLER=number
+$ export NVOIP_CALLED=number
+$ export NVOIP_AUDIO=path-to-audio-file
+```
+
+2. Run the script with the command:
+
+```bash
+$ sh send_torpedovoz_nvoip.sh
+```
+
+or, (if you do not follow the step 1):
+
+```bash
+$ NVOIP_TOKEN_AUTH=token NVOIP_CALLER=number NVOIP_CALLED=number NVOIP_AUDIO=path-to-audio-file sh send_torpedovoz_nvoip.sh
+```
 
 3. Ready. You will now receive the Voice Call Message.

--- a/Scripts/send_sms_nvoip.sh
+++ b/Scripts/send_sms_nvoip.sh
@@ -12,25 +12,26 @@
 
 #You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-###Inicio do Script / Start Script ###
+### Inicio do Script / Start Script ###
+
+# $NVOIP_TOKEN_AUTH
 # Seu Token da Nvoip. Acesse https://www.nvoip.com.br, crie sua para ter acesso ao seu Token.
 # English: Your Nvoip Token. Visit https://www.nvoip.com.br, create yours to have access to your Token.
-token_auth="Token Nvoip"
 
-#Celular que irá receber a mensagem.
-#English: Mobile phone will receive the message.
-celular="Celular/Mobile Number"
+# $NVOIP_CELULAR
+# Celular que irá receber a mensagem.
+# English: Mobile phone will receive the message.
 
-#Mensagem a ser enviada (Limite-se a 140 caracteres).
-#English: Message to send.
-msg="Mensagem a ser disparada"
+# $NVOIP_MSG
+# Mensagem a ser enviada (Limite-se a 140 caracteres).
+# English: Message to send.
 
 curl --include \
      --request POST \
      --header "Content-Type: application/json" \
-     --header "token_auth: $token_auth" \
+     --header "token_auth: $NVOIP_TOKEN_AUTH" \
      --data-binary "{
-    \"celular\":\"$celular\",
-    \"msg\":\"$msg\"
+    \"celular\":\"$NVOIP_CELULAR\",
+    \"msg\":\"$NVOIP_MSG\"
 }" \
 'https://api.nvoip.com.br/v1/sms'

--- a/Scripts/send_sms_nvoip.sh
+++ b/Scripts/send_sms_nvoip.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 #Nvoip - SMS
 
 #Copyright (C) 2020 Nvoip Plataforma Telefonia Ltda

--- a/Scripts/send_torpedovoz_nvoip.sh
+++ b/Scripts/send_torpedovoz_nvoip.sh
@@ -13,30 +13,30 @@
 #You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ###Inicio do Script###
+
+# $TOKEN_AUTH
 # Seu Token da Nvoip. Acesse https://www.nvoip.com.br, crie sua para ter acesso ao seu Token.
 # English: Your Nvoip Token. Visit https://www.nvoip.com.br, create yours to have access to your Token.
 
-token_auth="TOKEN NVOIP"
-
+# $NVOIP_CALLER
 # O número do seu usuário(ramal) na Nvoip. O mesmo não precisa estar online.
 # English: Your Nvoip username (extension). It does not have to be online.
-caller="USUÁRIO NVOIP"
 
-#O telefone que irá receber a ligação.
-#English: Phone will receive the voice call.
-called="Telefone/Phone"
+# $NVOIP_CALLED
+# O telefone que irá receber a ligação.
+# English: Phone will receive the voice call.
 
-#Texto que irá ser lido ou URL de arquivo MP3 que será tocado. A URL deve estar pública na internet e quando acessada via navegador, deverá abrir o player e começar a tocar.
-#English: Text to be read or MP3 file URL to be played. The URL must be public on the internet and when accessed via a browser, should open the player and start playing.
-audio="Texto/MP3"
+# $NVOIP_AUDIO
+# Texto que irá ser lido ou URL de arquivo MP3 que será tocado. A URL deve estar pública na internet e quando acessada via navegador, deverá abrir o player e começar a tocar.
+# English: Text to be read or MP3 file URL to be played. The URL must be public on the internet and when accessed via a browser, should open the player and start playing.
 
 curl --include \
      --request POST \
      --header "Content-Type: application/json" \
-     --header "token_auth: $token_auth" \
+     --header "token_auth: $NVOIP_TOKEN_AUTH" \
      --data-binary "{
-    \"caller\":\"$caller\",
-    \"called\":\"$called\",
-    \"audio\":\"$audio\"
+    \"caller\":\"$NVOIP_CALLER\",
+    \"called\":\"$NVOIP_CALLED\",
+    \"audio\":\"$NVOIP_AUDIO\"
 }" \
 'https://api.nvoip.com.br/v1/torpedovoz'

--- a/Scripts/send_torpedovoz_nvoip.sh
+++ b/Scripts/send_torpedovoz_nvoip.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 #Nvoip - Torpedo de Voz Shell Script
 
 #Copyright (C) 2020 Nvoip Plataforma Telefonia Ltda


### PR DESCRIPTION
Foram feitas algumas alterações no arquivo de script de modo a aplicar valores vindos de variáveis de ambiente onde o usuário pode guardar esses valores em outro lugar. Um problema que foi corrigido foi o de deixar o token do usuário exposto no arquivo de script, o que pode ser um grave problema. Ex.: permissões de leitura para certos tipos de usuários onde o token pode ser livremente acessado.

Foram feitas também alterações nas instruções de uso tanto em português como em inglês. Algumas podem ter ficado sem informação necessária devido a eu não ter acesso a documentação da API.